### PR TITLE
jpegtran integration to fix flaky comparision due to progressive jpegs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:buster-slim
+
+USER root
+RUN mkdir -p /usr/share/man/man1
+RUN apt-get update \
+    && apt-get install -y wget \
+    && apt-get install -yf default-jre-headless chromium libjpeg-progs \
+    && wget -U "jlineup-docker" -O jlineup-web.jar http://central.maven.org/maven2/de/otto/jlineup-web/3.0.0-rc7/jlineup-web-3.0.0-rc7.jar
+RUN apt-get remove --auto-remove perl -yf && apt-get purge --auto-remove perl -yf
+EXPOSE 8080
+
+ENTRYPOINT ["java","-jar","/jlineup-web.jar"]


### PR DESCRIPTION
This PR adds an option `baseline-jpeg-images` (default is false). It makes use of the [jpegtran ](https://www.systutorials.com/docs/linux/man/1-jpegtran/) tool which is available for linux and mac which creates baselined versions of progressive jpegs.
Using progressive jpegs in webpages may cause flaky results in the screenshot diffs even if the images stay the same 