### PR TITLE
add Dockerfile for first dockerized jlineup-web approach with chromium

### DIFF
--- a/web/src/main/java/de/otto/jlineup/web/JLineupController.java
+++ b/web/src/main/java/de/otto/jlineup/web/JLineupController.java
@@ -33,12 +33,15 @@ public class JLineupController {
     }
 
     @PostMapping(value = "/runs")
-    public ResponseEntity<Void> runBefore(@RequestBody JobConfig jobConfig, HttpServletRequest request) throws Exception {
+    public ResponseEntity<RunBeforeResponse> runBefore(@RequestBody JobConfig jobConfig, HttpServletRequest request) throws Exception {
         String id = jLineupService.startBeforeRun(jobConfig).getId();
 
         HttpHeaders headers = new HttpHeaders();
         headers.setLocation(URI.create(request.getContextPath() + "/runs/" + id));
-        return new ResponseEntity<>(headers, HttpStatus.ACCEPTED);
+
+        return ResponseEntity.accepted()
+                .headers(headers)
+                .body(new RunBeforeResponse(id));
     }
 
     @PostMapping("/runs/{runId}")

--- a/web/src/main/java/de/otto/jlineup/web/RunBeforeResponse.java
+++ b/web/src/main/java/de/otto/jlineup/web/RunBeforeResponse.java
@@ -1,0 +1,12 @@
+package de.otto.jlineup.web;
+
+public class RunBeforeResponse {
+    private final String id;
+
+    public RunBeforeResponse(String id) {
+        this.id = id;
+    }
+    public String getId() {
+        return id;
+    }
+}

--- a/web/src/test/java/de/otto/jlineup/web/JLineupControllerTest.java
+++ b/web/src/test/java/de/otto/jlineup/web/JLineupControllerTest.java
@@ -139,6 +139,7 @@ public class JLineupControllerTest {
         // then
         result
                 .andExpect(status().isAccepted())
+                .andExpect(content().json("{\"id\":\"someNewId\"}"))
                 .andExpect(header().string("Location", "/testContextPath/runs/someNewId"));
 
         verify(jLineupService).startBeforeRun(jobConfig);


### PR DESCRIPTION
using this dockerfile one is able to start of a jlineup-web server using jre-11 and chromium.
just build it using:
`docker build . -t otto-de/jlineup-web:3.0.0-rc7`

the service then can be started using:
`docker run -p 8080:8080 otto-de/jlineup-web`

Although using debian-slim there is still a problem with the docker image size caused by the dependencies of chromium. Maybe other browsers wont use that much space