### PR TITLE
Fix report page UI

### DIFF
--- a/web/src/main/resources/templates/error.html
+++ b/web/src/main/resources/templates/error.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 
 <head th:replace="~{fragments/head  :: head}" />

--- a/web/src/main/resources/templates/reports.html
+++ b/web/src/main/resources/templates/reports.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 
 <head th:replace="~{fragments/head :: head}" />

--- a/web/src/main/resources/templates/reports.html
+++ b/web/src/main/resources/templates/reports.html
@@ -96,7 +96,7 @@
         </div>
         <div class="panel-body">
             <div id="after-run-alert" class="alert d-none mt-2" role="alert"></div>
-            <table class="table table-light table-striped">
+            <table class="table table-striped">
                 <thead>
                 <tr>
                     <th>ID</th>


### PR DESCRIPTION
This PR fixes:
-Dark mode toggle button misalignment on the report page
-Use dark theme on the reports page panel body

Before Changes:
<img width="1723" height="269" alt="Bildschirmfoto 2026-05-12 um 09 55 05" src="https://github.com/user-attachments/assets/9170a63d-52e9-4df6-90d5-8e3d083ccc8e" />


After Changes:
<img width="1724" height="244" alt="Bildschirmfoto 2026-05-12 um 09 54 02" src="https://github.com/user-attachments/assets/c963249c-f26a-471a-8600-e14e1a09e35a" />