### PR TITLE
fix(lambda): ship logback config so the lambda stops logging at DEBUG

### DIFF
--- a/lambda/Dockerfile.chrome
+++ b/lambda/Dockerfile.chrome
@@ -72,6 +72,8 @@ RUN /usr/local/bin/chromedriver --version
 
 # Copy function code and runtime dependencies from Gradle layout
 COPY build/classes/java/main ${LAMBDA_TASK_ROOT}
+# Resources contain logback.xml; without it Logback defaults to DEBUG on the root logger
+COPY build/resources/main ${LAMBDA_TASK_ROOT}
 COPY build/output/lib/* ${LAMBDA_TASK_ROOT}/lib/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)

--- a/lambda/Dockerfile.firefox
+++ b/lambda/Dockerfile.firefox
@@ -60,6 +60,8 @@ RUN firefox --version
 
 # Copy function code and runtime dependencies from Gradle layout
 COPY build/classes/java/main ${LAMBDA_TASK_ROOT}
+# Resources contain logback.xml; without it Logback defaults to DEBUG on the root logger
+COPY build/resources/main ${LAMBDA_TASK_ROOT}
 COPY build/output/lib/* ${LAMBDA_TASK_ROOT}/lib/
 
 # Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)

--- a/lambda/Dockerfile.webkit
+++ b/lambda/Dockerfile.webkit
@@ -73,6 +73,8 @@ ENV HOME=/tmp/uusseerr
 
 # Copy function code and runtime dependencies from Gradle layout
 COPY build/classes/java/main ${LAMBDA_TASK_ROOT}
+# Resources contain logback.xml; without it Logback defaults to DEBUG on the root logger
+COPY build/resources/main ${LAMBDA_TASK_ROOT}
 COPY build/output/lib/* ${LAMBDA_TASK_ROOT}/lib/
 
 ENTRYPOINT [ "/lambda-entrypoint.sh" ]

--- a/lambda/src/main/resources/logback.xml
+++ b/lambda/src/main/resources/logback.xml
@@ -1,0 +1,29 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <Target>System.out</Target>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Suppress verbose AWS SDK debug output -->
+    <logger name="software.amazon.awssdk" level="WARN"/>
+    <logger name="software.amazon.awscdk" level="WARN"/>
+    <logger name="com.amazonaws" level="WARN"/>
+    <logger name="io.netty" level="WARN"/>
+    <logger name="org.apache.http" level="WARN"/>
+
+    <!-- Selenium / WebDriver chatter -->
+    <logger name="org.openqa.selenium" level="WARN"/>
+    <logger name="org.openqa.selenium.remote" level="WARN"/>
+    <logger name="io.github.bonigarcia" level="INFO"/>
+
+    <!-- Keep JLineup's own output at INFO -->
+    <logger name="de.otto.jlineup" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/lambda/src/main/resources/logback.xml
+++ b/lambda/src/main/resources/logback.xml
@@ -17,7 +17,6 @@
     <!-- Selenium / WebDriver chatter -->
     <logger name="org.openqa.selenium" level="WARN"/>
     <logger name="org.openqa.selenium.remote" level="WARN"/>
-    <logger name="io.github.bonigarcia" level="INFO"/>
 
     <!-- Keep JLineup's own output at INFO -->
     <logger name="de.otto.jlineup" level="INFO"/>


### PR DESCRIPTION
Fixes #2261

Without a logging config on the classpath, Logback falls back to `BasicConfigurator` and puts the root logger at DEBUG, flooding CloudWatch with AWS SDK internals on every invocation.

Changes:

- Add `lambda/src/main/resources/logback.xml`: root at INFO, with `software.amazon.awssdk`, `com.amazonaws`, `io.netty`, `org.apache.http` and `org.openqa.selenium` turned down to WARN. `de.otto.jlineup` stays at INFO.
- Copy `build/resources/main` into `${LAMBDA_TASK_ROOT}` in `Dockerfile.chrome`, `Dockerfile.firefox` and `Dockerfile.webkit`. Without this the config would not be packaged at all.

Verified:

- `./gradlew :jlineup-lambda:processResources` produces `lambda/build/resources/main/logback.xml` at the path the Dockerfiles copy from.
- None of the 126 runtime jars in `build/output/lib/` contain a competing `logback.xml`, so there is no classpath ordering ambiguity.